### PR TITLE
Handle invalid numeric input for CLI

### DIFF
--- a/drift_to_ppm_ppb.py
+++ b/drift_to_ppm_ppb.py
@@ -75,12 +75,15 @@ if __name__ == "__main__":
     ppm_input = input("PPM: ").strip()
     ppb_input = input("PPB: ").strip()
 
-    ppm_value = float(ppm_input) if ppm_input else None
-    ppb_value = float(ppb_input) if ppb_input else None
-
     try:
-        drift = ppm_ppb_to_drift(ppm=ppm_value, ppb=ppb_value)
-    except ValueError as exc:
-        print(f"Error: {exc}")
+        ppm_value = float(ppm_input) if ppm_input else None
+        ppb_value = float(ppb_input) if ppb_input else None
+    except ValueError:
+        print("Error: Please enter numeric values for PPM/PPB.")
     else:
-        print(f"Estimated drift over a day: {drift:+.6f} seconds")
+        try:
+            drift = ppm_ppb_to_drift(ppm=ppm_value, ppb=ppb_value)
+        except ValueError as exc:
+            print(f"Error: {exc}")
+        else:
+            print(f"Estimated drift over a day: {drift:+.6f} seconds")


### PR DESCRIPTION
## Summary
- wrap numeric parsing of PPM/PPB input values in a try/except block
- emit a clear error when non-numeric input is provided and skip drift calculation
- preserve existing validation by running ppm/ppb consistency check only after successful parsing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d45678e7848320978a847488d99f88