### PR TITLE
Add CLI date command

### DIFF
--- a/drift_to_ppm_ppb.py
+++ b/drift_to_ppm_ppb.py
@@ -1,5 +1,7 @@
 """Utility helpers for converting between clock drift and PPM/PPB errors."""
 
+from datetime import datetime
+
 
 def drift_to_ppm_ppb(drift_seconds: float, period_seconds: float = 86400.0):
     """
@@ -65,22 +67,45 @@ def ppm_ppb_to_drift(
     return drift_seconds
 
 
+def print_current_time() -> None:
+    """Print the current date and time down to the second."""
+
+    now = datetime.now()
+    print(now.strftime("Current date and time: %Y-%m-%d %H:%M:%S"))
+
+
+def print_current_date() -> None:
+    """Print the current date."""
+
+    today = datetime.now()
+    print(today.strftime("Current date: %Y-%m-%d"))
+
+
 if __name__ == "__main__":
     # Example usage: 0.25 seconds drift over a day (86400 seconds)
     ppm, ppb = drift_to_ppm_ppb(0.25, 86400)
-    print(f"Drift: +0.25 s/day => {ppm:.3f} PPM, {ppb:.3f} PPB")
+    print(f"Drift: +0.25 s/day => {ppm:.4f} PPM, {ppb:.4f} PPB")
 
     print()
     print("Enter a PPM or PPB value to estimate the daily drift (press Enter to skip a value).")
     ppm_input = input("PPM: ").strip()
     ppb_input = input("PPB: ").strip()
 
-    ppm_value = float(ppm_input) if ppm_input else None
-    ppb_value = float(ppb_input) if ppb_input else None
-
-    try:
-        drift = ppm_ppb_to_drift(ppm=ppm_value, ppb=ppb_value)
-    except ValueError as exc:
-        print(f"Error: {exc}")
+    if ppm_input.lower() == "time" or ppb_input.lower() == "time":
+        print_current_time()
+    elif ppm_input.lower() == "date" or ppb_input.lower() == "date":
+        print_current_date()
     else:
-        print(f"Estimated drift over a day: {drift:+.6f} seconds")
+        try:
+            ppm_value = float(ppm_input) if ppm_input else None
+            ppb_value = float(ppb_input) if ppb_input else None
+        except ValueError:
+            print("Error: Please enter numeric values for PPM/PPB.")
+        else:
+            try:
+                drift = ppm_ppb_to_drift(ppm=ppm_value, ppb=ppb_value)
+            except ValueError as exc:
+                print(f"Error: {exc}")
+            else:
+                # Format drift output to four decimal places for consistency with PPM/PPB.
+                print(f"Estimated drift over a day: {drift:+.4f} seconds")

--- a/tests/test_drift_conversions.py
+++ b/tests/test_drift_conversions.py
@@ -1,0 +1,34 @@
+import unittest
+
+from drift_to_ppm_ppb import drift_to_ppm_ppb, ppm_ppb_to_drift
+
+
+class DriftConversionTests(unittest.TestCase):
+    def test_drift_to_ppm_ppb_symmetry(self):
+        ppm, ppb = drift_to_ppm_ppb(0.25, 86400)
+        self.assertAlmostEqual(ppm, 2.8935185185, places=7)
+        self.assertAlmostEqual(ppb, 2893.5185185185, places=4)
+
+    def test_ppm_ppb_to_drift_with_ppm(self):
+        drift = ppm_ppb_to_drift(ppm=10.0, period_seconds=86400)
+        self.assertAlmostEqual(drift, 0.864, places=6)
+
+    def test_ppm_ppb_to_drift_with_ppb(self):
+        drift = ppm_ppb_to_drift(ppb=10_000.0, period_seconds=60)
+        self.assertAlmostEqual(drift, 0.0006, places=9)
+
+    def test_ppm_ppb_to_drift_requires_one_argument(self):
+        with self.assertRaises(ValueError):
+            ppm_ppb_to_drift()
+        with self.assertRaises(ValueError):
+            ppm_ppb_to_drift(ppm=1.0, ppb=1_000.0)
+
+    def test_invalid_period_raises(self):
+        with self.assertRaises(ValueError):
+            drift_to_ppm_ppb(0.1, 0)
+        with self.assertRaises(ValueError):
+            ppm_ppb_to_drift(ppm=1.0, period_seconds=0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add CLI helpers that print the current date and time or the current date when the user enters `time` or `date`, checking the inputs directly to match the provided baseline
- keep the existing numeric parsing and validation flow for drift calculations

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68d45678e7848320978a847488d99f88