### PR TITLE
Handle date command in drift calculator CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,4 @@
-This is a simple calculator, put change log after every PR created and add change log in this file 
+This is a simple calculator, put change log after every PR created and add change log in this file
+
+## Changelog
+- 2025-02-14: Added command handling for "date" and "time" inputs along with improved CLI robustness.

--- a/drift_to_ppm_ppb.py
+++ b/drift_to_ppm_ppb.py
@@ -74,6 +74,13 @@ def print_current_time() -> None:
     print(now.strftime("Current date and time: %Y-%m-%d %H:%M:%S"))
 
 
+def print_current_date() -> None:
+    """Print the current calendar date."""
+
+    today = datetime.now()
+    print(today.strftime("Current date: %Y-%m-%d"))
+
+
 if __name__ == "__main__":
     # Example usage: 0.25 seconds drift over a day (86400 seconds)
     ppm, ppb = drift_to_ppm_ppb(0.25, 86400)
@@ -83,11 +90,23 @@ if __name__ == "__main__":
     print("Enter a PPM or PPB value to estimate the daily drift (press Enter to skip a value).")
     ppm_input = input("PPM: ").strip()
     ppb_input = input("PPB: ").strip()
-    codex/wrap-conversions-in-try-block
-    if ppm_input.lower() == "time" or ppb_input.lower() == "time":
-        print_current_time()
-    else:
-      try:
+
+    special_commands = {
+        "time": print_current_time,
+        "date": print_current_date,
+    }
+
+    handled_command = False
+    for user_input in (ppm_input, ppb_input):
+        command = user_input.lower()
+        if command in special_commands:
+            special_commands[command]()
+            handled_command = True
+
+    if handled_command:
+        raise SystemExit(0)
+
+    try:
         ppm_value = float(ppm_input) if ppm_input else None
         ppb_value = float(ppb_input) if ppb_input else None
     except ValueError:
@@ -98,8 +117,5 @@ if __name__ == "__main__":
         except ValueError as exc:
             print(f"Error: {exc}")
         else:
-          codex/wrap-conversions-in-try-block
             # Format drift output to four decimal places for consistency with PPM/PPB.
             print(f"Estimated drift over a day: {drift:+.6f} seconds")
-            main
-            main

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Pytest configuration helpers."""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- add a helper to print the current calendar date
- allow the interactive CLI to respond to the `date` and `time` commands before performing conversions
- ensure pytest can import the module even when executed via the `pytest` entry point

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db0e6c7c0883208228f8f7eff5681d