### PR TITLE
Add unix time CLI command and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,4 @@ This is a simple calculator, put change log after every PR created and add chang
 
 ## Changelog
 - 2025-02-14: Added command handling for "date" and "time" inputs along with improved CLI robustness.
+- 2025-02-17: Added "unix" command to display the current Unix time and introduced helper for deterministic testing.

--- a/drift_to_ppm_ppb.py
+++ b/drift_to_ppm_ppb.py
@@ -3,6 +3,16 @@
 from datetime import datetime
 
 
+def _now() -> datetime:
+    """Return the current local datetime.
+
+    A dedicated helper makes it straightforward to patch the current time in
+    tests without needing to monkeypatch :func:`datetime.datetime.now`.
+    """
+
+    return datetime.now()
+
+
 def drift_to_ppm_ppb(drift_seconds: float, period_seconds: float = 86400.0):
     """
     Convert time drift in seconds to parts per million (PPM) and parts per billion (PPB).
@@ -70,15 +80,22 @@ def ppm_ppb_to_drift(
 def print_current_time() -> None:
     """Print the current date and time down to the second."""
 
-    now = datetime.now()
+    now = _now()
     print(now.strftime("Current date and time: %Y-%m-%d %H:%M:%S"))
 
 
 def print_current_date() -> None:
     """Print the current calendar date."""
 
-    today = datetime.now()
+    today = _now()
     print(today.strftime("Current date: %Y-%m-%d"))
+
+
+def print_current_unix_time() -> None:
+    """Print the current Unix time to the nearest second."""
+
+    unix_time = int(_now().timestamp())
+    print(f"Current Unix time: {unix_time}")
 
 
 if __name__ == "__main__":
@@ -94,6 +111,7 @@ if __name__ == "__main__":
     special_commands = {
         "time": print_current_time,
         "date": print_current_date,
+        "unix": print_current_unix_time,
     }
 
     handled_command = False

--- a/tests/test_drift_conversions.py
+++ b/tests/test_drift_conversions.py
@@ -1,6 +1,14 @@
+import contextlib
+import io
 import unittest
+from datetime import datetime
+from unittest.mock import patch
 
-from drift_to_ppm_ppb import drift_to_ppm_ppb, ppm_ppb_to_drift
+from drift_to_ppm_ppb import (
+    drift_to_ppm_ppb,
+    ppm_ppb_to_drift,
+    print_current_unix_time,
+)
 
 
 class DriftConversionTests(unittest.TestCase):
@@ -28,6 +36,18 @@ class DriftConversionTests(unittest.TestCase):
             drift_to_ppm_ppb(0.1, 0)
         with self.assertRaises(ValueError):
             ppm_ppb_to_drift(ppm=1.0, period_seconds=0)
+
+
+class CommandOutputTests(unittest.TestCase):
+    def test_print_current_unix_time(self):
+        fake_now = datetime(2024, 6, 1, 12, 34, 56)
+
+        with patch("drift_to_ppm_ppb._now", return_value=fake_now):
+            buffer = io.StringIO()
+            with contextlib.redirect_stdout(buffer):
+                print_current_unix_time()
+
+        self.assertEqual(buffer.getvalue().strip(), "Current Unix time: 1717245296")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a `unix` CLI command that prints the current Unix timestamp to the nearest second
- introduce a `_now()` helper to make time-dependent behaviour easier to test and extend
- cover the new command with unit tests and update the project changelog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db0fa35fe8832086c58c5b4b3cbdd1