### PR TITLE
Add hello command that echoes user input

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 This is a simple calculator, put change log after every PR created and add change log in this file, use current date and time for changelog when the PR is being generated
 
 ## Changelog
+- 2025-09-29 23:16 UTC: Added "hello" command to echo the user input back to the console.
 - 2025-02-14: Added command handling for "date" and "time" inputs along with improved CLI robustness.
 - 2025-02-17: Added "unix" command to display the current Unix time and introduced helper for deterministic testing.
 

--- a/drift_to_ppm_ppb.py
+++ b/drift_to_ppm_ppb.py
@@ -98,6 +98,12 @@ def print_current_unix_time() -> None:
     print(f"Current Unix time: {unix_time}")
 
 
+def print_hello() -> None:
+    """Echo "hello" back to the caller."""
+
+    print("hello")
+
+
 if __name__ == "__main__":
     # Example usage: 0.25 seconds drift over a day (86400 seconds)
     ppm, ppb = drift_to_ppm_ppb(0.25, 86400)
@@ -112,6 +118,7 @@ if __name__ == "__main__":
         "time": print_current_time,
         "date": print_current_date,
         "unix": print_current_unix_time,
+        "hello": print_hello,
     }
 
     handled_command = False

--- a/tests/test_drift_conversions.py
+++ b/tests/test_drift_conversions.py
@@ -8,6 +8,7 @@ from drift_to_ppm_ppb import (
     drift_to_ppm_ppb,
     ppm_ppb_to_drift,
     print_current_unix_time,
+    print_hello,
 )
 
 
@@ -48,6 +49,13 @@ class CommandOutputTests(unittest.TestCase):
                 print_current_unix_time()
 
         self.assertEqual(buffer.getvalue().strip(), "Current Unix time: 1717245296")
+
+    def test_print_hello(self):
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            print_hello()
+
+        self.assertEqual(buffer.getvalue().strip(), "hello")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a reusable print_hello helper that echoes "hello"
- allow the CLI to recognize the "hello" command and print the greeting
- cover the new helper with a unit test and update the changelog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db131ca2088320af7d5e86d6b2784f